### PR TITLE
Use book cover as a sleep image

### DIFF
--- a/pocketbookcover.koplugin/main.lua
+++ b/pocketbookcover.koplugin/main.lua
@@ -30,6 +30,9 @@ function PocketbookCover:update(title, page)
 
     image = RenderImage:scaleBlitBuffer(image, width, height)
     image:writeToFile("/mnt/ext1/system/logo/bookcover", "bmp", 100, false)
+    
+    imagesleep = RenderImage:scaleBlitBuffer(image, width, height)
+    imagesleep:writeToFile("/mnt/ext1/system/resources/Line/taskmgr_lock_background.bmp", "bmp", 100, false)
 end
 
 function PocketbookCover:onReaderReady(doc)


### PR DESCRIPTION
According to the [article](http://cyfranek.booklikes.com/post/5815379/poradnik-wlasna-grafika-usypiania-dla-czytnikow-pocketbook), code was updated to use book cover for a sleep image.

The only not elegant thing is that if you finished the book and started new one, after sleep the image is not changing. Power off/on is needed.

For convenience, would be good to add an option in koreader menu to choose which image/-es (power off / sleep) to replace with book cover. But I'm lacking a skill for such a thing.